### PR TITLE
Expose the flush method of the underlying socket

### DIFF
--- a/lib/src/network_printer.dart
+++ b/lib/src/network_printer.dart
@@ -44,6 +44,11 @@ class NetworkPrinter {
     }
   }
 
+  /// Flush all buffered print commands
+  Future<void> flush() async {
+    await _socket.flush();
+  }
+
   /// [delayMs]: milliseconds to wait after destroying the socket
   void disconnect({int? delayMs}) async {
     _socket.destroy();


### PR DESCRIPTION
This PR exposes the `flush()` method of the underlying socket. The `flush()` function should be used before disconnecting in order to send all buffered printing commands to the printer. Under some circumstances (long print jobs, slow network, ...) the printer may not be done printing before a disconnect. Then the last few lines are not printed and the paper may not get cut.

Usage of the exposed `flush()` method:
```dart
await printer.flush();
printer.disconnect();
```
