### PR TITLE
fix: set 9100 default port for ESC/POS

### DIFF
--- a/lib/src/network_printer.dart
+++ b/lib/src/network_printer.dart
@@ -32,7 +32,7 @@ class NetworkPrinter {
   CapabilityProfile get profile => _profile;
 
   Future<PosPrintResult> connect(String host,
-      {int port = 91000, Duration timeout = const Duration(seconds: 5)}) async {
+      {int port = 9100, Duration timeout = const Duration(seconds: 5)}) async {
     _host = host;
     _port = port;
     try {


### PR DESCRIPTION
Set the correct default port for ESC/POS in the connection method if the user does not inform